### PR TITLE
Add support for MySQL JSON column type (245) in binary protocol

### DIFF
--- a/lib/src/mysql_protocol/mysql_column_type.dart
+++ b/lib/src/mysql_protocol/mysql_column_type.dart
@@ -472,6 +472,13 @@ Tuple2<dynamic, int> parseBinaryColumnData(
         final yearValue = data.getUint16(startOffset, Endian.little);
         return Tuple2(yearValue.toString(), 2);
       }
+
+    case mysqlColumnTypeJson:
+      {
+        // MySQL JSON is sent as length-encoded UTF-8 string
+        final result = buffer.getUtf8LengthEncodedString(startOffset);
+        return Tuple2(result.item1, result.item2);
+      }
   }
 
   throw MySQLProtocolException(


### PR DESCRIPTION
MySQL JSON columns are reported as type 245 (0xF5) in the binary protocol.
Currently, mysql_dart throws a MySQLProtocolException when encountering this type.

This PR adds support for JSON columns by parsing them as UTF-8 length-encoded strings, which is consistent with how MySQL transmits JSON values.

This enables compatibility with schemas generated by tools like Prisma and avoids protocol-level crashes.